### PR TITLE
Accidental inclusion of a defective preview feature leading to wide performance difference

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.1.1",
-    "@prisma/client": "5.1.1",
+    "@prisma/client": "5.11.0",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",
     "drizzle-orm": "^0.28.1",
     "hono": "^3.4.1",
     "pg": "^8.11.2",
     "pidusage": "^3.0.2",
-    "prisma": "^5.1.1",
+    "prisma": "^5.11.0",
     "ramda": "^0.29.0"
   }
 }

--- a/src/prisma-server.ts
+++ b/src/prisma-server.ts
@@ -26,13 +26,9 @@ app.get("/customer-by-id", async (c) => {
 });
 
 app.get("/search-customer", async (c) => {
-  const result = await prisma.customer.findMany({
-    where: {
-      companyName: {
-        search: `${c.req.query("term")}:*`,
-      },
-    },
-  });
+  const term = `${c.req.query("term")}:*`;
+  const result = await prisma.$queryRaw`select * from "customers" where to_tsvector('english', "customers"."companyName") @@ to_tsquery('english', ${term});`;
+
 
   return c.json(result);
 });
@@ -104,13 +100,8 @@ app.get("/product-with-supplier", async (c) => {
 });
 
 app.get("/search-product", async (c) => {
-  const result = await prisma.product.findMany({
-    where: {
-      name: {
-        search: `${c.req.query("term")}:*`,
-      },
-    },
-  });
+  const term = `${c.req.query("term")}:*`;
+  const result = await prisma.$queryRaw`select * from "products" where to_tsvector('english', "products"."name") @@ to_tsquery('english', ${term});`;
 
   return c.json(result);
 });

--- a/src/schema.prisma
+++ b/src/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["referentialIntegrity", "fullTextSearch", "fullTextIndex"]
   binaryTargets   = ["native", "rhel-openssl-1.0.x"]
 }
 


### PR DESCRIPTION
Hey Drizzle team 👋

First of all, thanks a lot for putting in the effort to create these benchmarks comparing Drizzle with Prisma ORM. We found these to be a useful resource for performance comparisons and appreciate your work!

### Accidental inclusion of a defective preview feature leading to the wide performance difference

While reviewing the benchmark, we have discovered that most queries perform almost identical between Drizzle and Prisma. Two queries use the experimental full-text search feature, which is in preview. Almost the entire difference in performance can be attributed to those two queries.

This defective preview feature can be found in two routes in the benchmark setup where FTS is being used:

- [/search-customer](https://github.com/drizzle-team/drizzle-benchmarks/blob/main/src/prisma-server.ts#L28-L35)
- [/search-product](https://github.com/drizzle-team/drizzle-benchmarks/blob/main/src/prisma-server.ts#L106-L116)

We have [documented](https://github.com/prisma/prisma/issues/23627) the performance issue with this preview feature, and provided instructions for how to perform full-text search with a raw SQL query to avoid this performance problem.

As you will see in the benchmark output below, changing these two routes to use raw SQL queries causes Drizzle and Prisma to perform very similar.

### If we fix the broken query, Prisma ORM and Drizzle have similar performance

If we drop the broken preview feature and replace it with a raw SQL query (using Prisma ORM’s `$queryRaw` escape hatch), the results show that Prisma ORM and Drizzle are in the same ballpark when it comes to performance. In that case, Drizzle is about 8% faster (in terms of the iterations measured by k6):


|                        | Drizzle                              | Prisma ORM                           |
| ---------------------- | ------------------------------------ | ------------------------------------ |
| Raw results            | ![](https://i.imgur.com/69Qp0fG.png)      | ![](https://i.imgur.com/GgWlHBY.png)      |
| Iterations per second  | 4814                                 | 4414                                 |
| Avg iteration duration | 517 ms                              | 564 ms                              |


I also ran the initial setup with the defective fulltext-search feature, and can confirm that the results for Prisma are about 5x worse in that case.

This PR changes the full-text search queries to use raw SQL, and updates Prisma to the latest version.

To ensure that developers can still successfully use full-text search with Prisma ORM, we have updated our [documentation](https://www.prisma.io/docs/orm/prisma-client/queries/full-text-search#full-text-search-with-raw-sql) with instructions to drop down to raw SQL if they observe slow queries using the `search` API.